### PR TITLE
Fixed broken docs link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -17,4 +17,4 @@ We follow the style guidelines for QMK and have provided a yapf config in setup.
 
 Our documentation lives on GitBook and can be found here:
 
-> https://docs.compile.qmk.fm
+> https://docs.api.qmk.fm/using-the-api


### PR DESCRIPTION
This PR fixes broken docs link in `readme.md` (from `https://docs.compile.qmk.fm` to `https://docs.api.qmk.fm/using-the-api`)

Fixes: #42