### PR TITLE
[Docs] Update URL of endpoint (compile.qmk.fm→api.qmk.fm) and KEYMAP→LAYOUT

### DIFF
--- a/docs/api_docs.md
+++ b/docs/api_docs.md
@@ -12,7 +12,7 @@ This service is an asynchronous API for compiling custom keymaps. You POST some 
 {
   "keyboard": "clueboard/66/rev2",
   "keymap": "my_awesome_keymap",
-  "layout": "KEYMAP",
+  "layout": "LAYOUT",
   "layers": [
     ["KC_GRV","KC_1","KC_2","KC_3","KC_4","KC_5","KC_6","KC_7","KC_8","KC_9","KC_0","KC_MINS","KC_EQL","KC_GRV","KC_BSPC","KC_PGUP","KC_TAB","KC_Q","KC_W","KC_E","KC_R","KC_T","KC_Y","KC_U","KC_I","KC_O","KC_P","KC_LBRC","KC_RBRC","KC_BSLS","KC_PGDN","KC_CAPS","KC_A","KC_S","KC_D","KC_F","KC_G","KC_H","KC_J","KC_K","KC_L","KC_SCLN","KC_QUOT","KC_NUHS","KC_ENT","KC_LSFT","KC_NUBS","KC_Z","KC_X","KC_C","KC_V","KC_B","KC_N","KC_M","KC_COMM","KC_DOT","KC_SLSH","KC_RO","KC_RSFT","KC_UP","KC_LCTL","KC_LGUI","KC_LALT","KC_MHEN","KC_SPC","KC_SPC","KC_HENK","KC_RALT","KC_RCTL","MO(1)","KC_LEFT","KC_DOWN","KC_RIGHT"],
     ["KC_ESC","KC_F1","KC_F2","KC_F3","KC_F4","KC_F5","KC_F6","KC_F7","KC_F8","KC_F9","KC_F10","KC_F11","KC_F12","KC_TRNS","KC_DEL","BL_STEP","KC_TRNS","KC_TRNS","KC_TRNS","KC_TRNS","KC_TRNS","KC_TRNS","_______","KC_TRNS","KC_PSCR","KC_SLCK","KC_PAUS","KC_TRNS","KC_TRNS","KC_TRNS","KC_TRNS","KC_TRNS","KC_TRNS","MO(2)","KC_TRNS","KC_TRNS","KC_TRNS","KC_TRNS","KC_TRNS","KC_TRNS","KC_TRNS","KC_TRNS","KC_TRNS","KC_TRNS","KC_TRNS","KC_TRNS","KC_TRNS","KC_TRNS","KC_TRNS","KC_TRNS","KC_TRNS","KC_TRNS","KC_TRNS","KC_TRNS","KC_TRNS","KC_TRNS","KC_TRNS","KC_TRNS","KC_TRNS","KC_PGUP","KC_TRNS","KC_TRNS","KC_TRNS","KC_TRNS","KC_TRNS","KC_TRNS","KC_TRNS","KC_TRNS","KC_TRNS","MO(1)","KC_LEFT","KC_PGDN","KC_RGHT"],
@@ -28,7 +28,7 @@ As you can see the payload describes all aspects of a keyboard necessary to crea
 To compile your keymap into a firmware simply POST your JSON to the `/v1/compile` endpoint. In the following example we've placed the JSON payload into a file named `json_data`.
 
 ```
-$ curl -H "Content-Type: application/json" -X POST -d "$(< json_data)" http://compile.qmk.fm/v1/compile
+$ curl -H "Content-Type: application/json" -X POST -d "$(< json_data)" http://api.qmk.fm/v1/compile
 {
   "enqueued": true,
   "job_id": "ea1514b3-bdfc-4a7b-9b5c-08752684f7f6"
@@ -40,7 +40,7 @@ $ curl -H "Content-Type: application/json" -X POST -d "$(< json_data)" http://co
 After submitting your keymap you can check the status using a simple HTTP GET call:
 
 ```
-$ curl http://compile.qmk.fm/v1/compile/ea1514b3-bdfc-4a7b-9b5c-08752684f7f6
+$ curl http://api.qmk.fm/v1/compile/ea1514b3-bdfc-4a7b-9b5c-08752684f7f6
 {
   "created_at": "Sat, 19 Aug 2017 21:39:12 GMT",
   "enqueued_at": "Sat, 19 Aug 2017 21:39:12 GMT",
@@ -63,7 +63,7 @@ This shows us that the job has made it through the queue and is currently runnin
 When your job has completed and the compilation was successful you can download your new firmware. To download only the .hex file for flashing append "hex" to your URL:
 
 ```
-$ curl -i http://compile.qmk.fm/v1/compile/9dbf56d1-9d6f-4d1a-a7e3-af1d6ecbdd65/hex
+$ curl -i http://api.qmk.fm/v1/compile/ea1514b3-bdfc-4a7b-9b5c-08752684f7f6/hex
 HTTP/1.0 200 OK
 Content-Disposition: attachment; filename=clueboard_rev2_my_awesome_keymap.hex
 Content-Length: 63558
@@ -84,7 +84,7 @@ Date: Sat, 19 Aug 2017 22:47:19 GMT
 If you'd like to download the source code as well as the hex you can append "source" instead:
 
 ```
-$ curl http://compile.qmk.fm/v1/compile/9dbf56d1-9d6f-4d1a-a7e3-af1d6ecbdd65/source > qmk_firmware.zip
+$ curl -L http://api.qmk.fm/v1/compile/ea1514b3-bdfc-4a7b-9b5c-08752684f7f6/source > qmk_firmware.zip
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                  Dload  Upload   Total   Spent    Left  Speed
 100 10.8M  100 10.8M    0     0  52.2M      0 --:--:-- --:--:-- --:--:-- 52.0M


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

`compile.qmk.fm/v1/compile` returns a 404 error code and using "KEYMAP" as the layout causes the compilation to fail.

I also changed the job id of the last two curl commands to stay consistent with previous curl calls.

<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->
