### PR TITLE
Fix kle converter mimetype

### DIFF
--- a/web.py
+++ b/web.py
@@ -291,7 +291,7 @@ def POST_v1_converters_kle():
         return error('Could not parse KLE raw data: %s', e)
 
     response = make_response(keyboard)
-    response.mimetype = app.config['JSONIFY_MIMETYPE']
+    response.mimetype = app.json.mimetype
 
     return response
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->
<https://qmk.fm/converter/> is currently failing, producing a 500.

Attempting to reproduce this locally shows:

```
  File "qmk_api/web.py", line 298, in POST_v1_converters_kle
    response.mimetype = app.config['JSONIFY_MIMETYPE']
                        ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
KeyError: 'JSONIFY_MIMETYPE'
```

<https://flask.palletsprojects.com/en/stable/config/>
> Changed in version 2.3: JSON_AS_ASCII, JSON_SORT_KEYS, JSONIFY_MIMETYPE, and JSONIFY_PRETTYPRINT_REGULAR were removed. The default app.json provider has equivalent attributes instead.


After this change:

```
curl -H "Content-Type: application/json" -X POST -d '{"raw":"[\"Num Lock\",\"/\",\"*\",\"-\"],\n[\"7\\nHome\",\"8\\n↑\",\"9\\nPgUp\",{h:2},\"+\"],\n[\"4\\n←\",\"5\",\"6\\n→\"],\n[\"1\\nEnd\",\"2\\n↓\",\"3\\nPgDn\",{h:2},\"Enter\"],\n[{w:2},\"0\\nIns\",\".\\nDel\"]\n"}' http://localhost:5001/v1/converters/kle
```

Now produces the expected:
```json
{
    "keyboard_name": "", 
    "url": "", 
    "maintainer": "qmk", 
    "layouts": {
        "LAYOUT": {
            "layout": [{"label":"Num Lock", "x":0, "y":0}, {"label":"/", "x":1, "y":0}, {"label":"*", "x":2, "y":0}, {"label":"-", "x":3, "y":0}, {"label":"7", "x":0, "y":1}, {"label":"8", "x":1, "y":1}, {"label":"9", "x":2, "y":1}, {"label":"+", "x":3, "y":1, "h":2}, {"label":"4", "x":0, "y":2}, {"label":"5", "x":1, "y":2}, {"label":"6", "x":2, "y":2}, {"label":"1", "x":0, "y":3}, {"label":"2", "x":1, "y":3}, {"label":"3", "x":2, "y":3}, {"label":"Enter", "x":3, "y":3, "h":2}, {"label":"0", "x":0, "y":4, "w":2}, {"label":".", "x":2, "y":4}]
        }
    }
}
```
